### PR TITLE
Add Wasm compatibility

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -24,7 +24,7 @@ find src -type f -exec sed -i '/The version of the OpenAPI document/d' {} \;
 find src -type f -exec sed -i '/^\s*\/\/\/\s*$/d' {} \;
 
 # Cookie storage
-sed -i 's/Client::new()/Client::builder().cookie_store(true).build().unwrap()/g' src/apis/configuration.rs
+sed -i 's/reqwest::Client::new()/{#[cfg(target_family = "wasm")] {reqwest::Client::new()}\n #[cfg(not(target_family = "wasm"))] { reqwest::Client::builder().cookie_store(true).build().unwrap()}\n }/g' src/apis/configuration.rs
 sed -i 's/features = \["json", "multipart"\]/features = \["json", "cookies", "multipart"\]/g' Cargo.toml
 
 #Fix example

--- a/generate.sh
+++ b/generate.sh
@@ -26,7 +26,7 @@ find src -type f -exec sed -i '/^\s*\/\/\/\s*$/d' {} \;
 # Cookie storage
 sed -i 's/reqwest::Client::new()/{#[cfg(target_family = "wasm")] {reqwest::Client::new()}\n #[cfg(not(target_family = "wasm"))] { reqwest::Client::builder().cookie_store(true).build().unwrap()}\n }/g' src/apis/configuration.rs
 sed -i 's/features = \["json", "multipart"\]/features = \["json", "cookies", "multipart"\]/g' Cargo.toml
-printf '\n[features]\njs = ["uuid/js"]\n' >> Cargo.toml # add wasm feature
+printf '\n[features]\njs = ["uuid/js"]\n' >> Cargo.toml
 
 #Fix example
 printf "\n[dev-dependencies]\ntokio = { version = '1', features = ['macros', 'rt-multi-thread'] }" >> Cargo.toml

--- a/generate.sh
+++ b/generate.sh
@@ -26,6 +26,7 @@ find src -type f -exec sed -i '/^\s*\/\/\/\s*$/d' {} \;
 # Cookie storage
 sed -i 's/reqwest::Client::new()/{#[cfg(target_family = "wasm")] {reqwest::Client::new()}\n #[cfg(not(target_family = "wasm"))] { reqwest::Client::builder().cookie_store(true).build().unwrap()}\n }/g' src/apis/configuration.rs
 sed -i 's/features = \["json", "multipart"\]/features = \["json", "cookies", "multipart"\]/g' Cargo.toml
+printf '\n[features]\njs = ["uuid/js"]\n' >> Cargo.toml # add wasm feature
 
 #Fix example
 printf "\n[dev-dependencies]\ntokio = { version = '1', features = ['macros', 'rt-multi-thread'] }" >> Cargo.toml

--- a/src/apis/configuration.rs
+++ b/src/apis/configuration.rs
@@ -40,7 +40,9 @@ impl Default for Configuration {
         Configuration {
             base_path: "https://vrchat.com/api/1".to_owned(),
             user_agent: Some("vrchatapi-rust".to_owned()),
-            client: reqwest::Client::builder().cookie_store(true).build().unwrap(),
+            client: {#[cfg(target_family = "wasm")] {reqwest::Client::new()}
+ #[cfg(not(target_family = "wasm"))] { reqwest::Client::builder().cookie_store(true).build().unwrap()}
+ },
             basic_auth: None,
             oauth_access_token: None,
             bearer_access_token: None,


### PR DESCRIPTION
Before the line `reqwest::Client::builder().cookie_store(true).build().unwrap()` would block compilation on wasm targets.
The error would be:
```
error[E0599]: no method named `cookie_store` found for struct `ClientBuilder` in the current scope
```

With this, compilation can still succeed.