### PR TITLE
Must not include default reqwest ssl feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,8 @@ reqwest = { version = "^0.12", default-features = false, features = ["json", "co
 
 [dev-dependencies]
 tokio = { version = '1', features = ['macros', 'rt-multi-thread'] }
+
+[features]
+default = ["rustls-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ serde_with = { version = "^3.8", default-features = false, features = ["base64",
 serde_json = "^1.0"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-reqwest = { version = "^0.12", features = ["json", "cookies", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "cookies", "multipart"] }
 
 [dev-dependencies]
 tokio = { version = '1', features = ['macros', 'rt-multi-thread'] }


### PR DESCRIPTION
`reqwest` by default enables the `native-tls` feature, which includes `openssl-sys`, but some systems are not setup to compile this, and even though the user selects `rustls-tls` in their `Cargo.toml`, `vrchatapi-rust` still requires `native-tls` be compiled.