### PR TITLE
Allow reqwest to be used without `default-tls`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,10 @@ serde_with = { version = "^3.8", default-features = false, features = ["base64",
 serde_json = "^1.0"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-reqwest = { version = "^0.12", features = ["json", "cookies", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "cookies", "multipart"] }
 
 [dev-dependencies]
 tokio = { version = '1', features = ['macros', 'rt-multi-thread'] }
+
+[features]
+default = ["reqwest/default"]

--- a/generate.sh
+++ b/generate.sh
@@ -25,10 +25,14 @@ find src -type f -exec sed -i '/^\s*\/\/\/\s*$/d' {} \;
 
 # Cookie storage
 sed -i 's/Client::new()/Client::builder().cookie_store(true).build().unwrap()/g' src/apis/configuration.rs
-sed -i 's/features = \["json", "multipart"\]/features = \["json", "cookies", "multipart"\]/g' Cargo.toml
+sed -i 's/, features = \["json", "multipart"\]/, default-features = false, features = \["json", "cookies", "multipart"\]/g' Cargo.toml
 
 #Fix example
 printf "\n[dev-dependencies]\ntokio = { version = '1', features = ['macros', 'rt-multi-thread'] }" >> Cargo.toml
+
+#Add feature section to Cargo.toml
+printf "\n[features]\ndefault = [\"reqwest/default\"]" >> Cargo.toml
+
 
 # https://github.com/vrchatapi/specification/issues/241
 cat patches/2FA_Current_User.rs >> src/models/current_user.rs


### PR DESCRIPTION
This allows reqwest to be used without `default-tls`, by disabling default features for the vrcapi and then selecting the tls library yourself.

This is currently a draft, because I have not yet tested that this approach actually works.

Supersedes: #22

(and again, because this is the one that GitHub actually picks up)
Closes: #22