### PR TITLE
Add a rustls-tls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,8 @@ reqwest = { version = "^0.12", default-features = false, features = ["json", "co
 
 [dev-dependencies]
 tokio = { version = '1', features = ['macros', 'rt-multi-thread'] }
+
 [features]
-default = ["reqwest/default"]
+default = ["rustls-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]


### PR DESCRIPTION
There has to be a feature to enable `reqwest/rustls-tls`, just disabling `reqwest/default`/`reqwest/native-tls` leaves reqwest without SSL, and no way to enable the alternate feature.