### PR TITLE
refactor: remove unnecessary code in examples

### DIFF
--- a/examples/cookies_load.rs
+++ b/examples/cookies_load.rs
@@ -11,7 +11,7 @@ async fn main() {
     config.basic_auth = Some((String::from("username"), Some(String::from("password"))));
     config.user_agent = Some(String::from("ExampleProgram/0.0.1 my@email.com"));
 
-    let mut jar = reqwest::cookie::Jar::default();
+    let jar = reqwest::cookie::Jar::default();
     jar.set_cookies(
         &mut [HeaderValue::from_str(
             &"auth=[AUTH_COOKIE_HERE], twoFactorAuth=[TWO_FACTOR_AUTH_COOKIE_HERE]",

--- a/examples/cookies_store.rs
+++ b/examples/cookies_store.rs
@@ -13,7 +13,6 @@ async fn main() {
 
     let cookie_store = std::sync::Arc::new(reqwest::cookie::Jar::default());
     config.client = reqwest::Client::builder()
-        .cookie_store(true)
         .cookie_provider(cookie_store.clone())
         .build()
         .unwrap();


### PR DESCRIPTION
Removed unnecessary `cookie_store(true)` call in [examples/cookies_store.rs](https://github.com/vrchatapi/vrchatapi-rust/compare/main...Raifa21:vrchatapi-rust:main?expand=1#diff-de9520076cbafd09ae5fc2dc0fd37711385e39fa17e7b7193fefd204362d5efe)

Removed unnecessary mutable assignment in [examples/cookies_load.rs](https://github.com/vrchatapi/vrchatapi-rust/compare/main...Raifa21:vrchatapi-rust:main?expand=1#diff-94afe12198b7149a5c286d7fa03bdc2c15f4d020809d800d7e016c58627635c1)