### PR TITLE
Avoid percent-encoding for "(" and ")" characters.

### DIFF
--- a/src/apis/mod.rs
+++ b/src/apis/mod.rs
@@ -66,8 +66,44 @@ impl<T> From<std::io::Error> for Error<T> {
     }
 }
 
+fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn parse_percent_encoded(bytes: &[u8; 3]) -> Option<u8> {
+    if bytes[0] != b'%' { return None; }
+    let hi = hex_digit(bytes[1])?;
+    let lo = hex_digit(bytes[2])?;
+    Some((hi << 4) | lo)
+}
+
 pub fn urlencode<T: AsRef<str>>(s: T) -> String {
-    ::url::form_urlencoded::byte_serialize(s.as_ref().as_bytes()).collect()
+    ::url::form_urlencoded::byte_serialize(s.as_ref().as_bytes())
+        .map(|string| {
+            debug_assert!(
+                !string.starts_with('%') || string.len() == 3,
+                "the iterator should yield percent-encoded strings of exactly 3 bytes, or unescaped strings"
+            );
+
+            let parsed = match string.as_bytes().try_into() {
+                Ok(bytes) => parse_percent_encoded(bytes),
+                Err(_) => None,
+            };
+
+            // The VRChat API deviates from the application/x-www-form-urlencoded percent-encode set, for values like the InstanceID.
+            // The characters bellow should remain unchanged for URI parameters, or requests will be rejected as malformed.
+            match parsed {
+                Some(b'(') => "(",
+                Some(b')') => ")",
+                _ => string
+            }
+        })
+        .collect()
 }
 
 pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String, String)> {

--- a/templates/reqwest-trait/api_mod.mustache
+++ b/templates/reqwest-trait/api_mod.mustache
@@ -95,8 +95,44 @@ impl <T> From<std::io::Error> for Error<T> {
     }
 }
 
+fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn parse_percent_encoded(bytes: &[u8; 3]) -> Option<u8> {
+    if bytes[0] != b'%' { return None; }
+    let hi = hex_digit(bytes[1])?;
+    let lo = hex_digit(bytes[2])?;
+    Some((hi << 4) | lo)
+}
+
 pub fn urlencode<T: AsRef<str>>(s: T) -> String {
-    ::url::form_urlencoded::byte_serialize(s.as_ref().as_bytes()).collect()
+    ::url::form_urlencoded::byte_serialize(s.as_ref().as_bytes())
+        .map(|string| {
+            debug_assert!(
+                !string.starts_with('%') || string.len() == 3,
+                "the iterator should yield percent-encoded strings of exactly 3 bytes, or unescaped strings"
+            );
+
+            let parsed = match string.as_bytes().try_into() {
+                Ok(bytes) => parse_percent_encoded(bytes),
+                Err(_) => None,
+            };
+
+            // The VRChat API deviates from the application/x-www-form-urlencoded percent-encode set, for values like the InstanceID.
+            // The characters bellow should remain unchanged for URI parameters, or requests will be rejected as malformed.
+            match parsed {
+                Some(b'(') => "(",
+                Some(b')') => ")",
+                _ => string
+            }
+        })
+        .collect()
 }
 
 pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String, String)> {

--- a/templates/reqwest/api_mod.mustache
+++ b/templates/reqwest/api_mod.mustache
@@ -118,8 +118,44 @@ impl <T> From<std::io::Error> for Error<T> {
     }
 }
 
+fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn parse_percent_encoded(bytes: &[u8; 3]) -> Option<u8> {
+    if bytes[0] != b'%' { return None; }
+    let hi = hex_digit(bytes[1])?;
+    let lo = hex_digit(bytes[2])?;
+    Some((hi << 4) | lo)
+}
+
 pub fn urlencode<T: AsRef<str>>(s: T) -> String {
-    ::url::form_urlencoded::byte_serialize(s.as_ref().as_bytes()).collect()
+    ::url::form_urlencoded::byte_serialize(s.as_ref().as_bytes())
+        .map(|string| {
+            debug_assert!(
+                !string.starts_with('%') || string.len() == 3,
+                "the iterator should yield percent-encoded strings of exactly 3 bytes, or unescaped strings"
+            );
+
+            let parsed = match string.as_bytes().try_into() {
+                Ok(bytes) => parse_percent_encoded(bytes),
+                Err(_) => None,
+            };
+
+            // The VRChat API deviates from the application/x-www-form-urlencoded percent-encode set, for values like the InstanceID.
+            // The characters bellow should remain unchanged for URI parameters, or requests will be rejected as malformed.
+            match parsed {
+                Some(b'(') => "(",
+                Some(b')') => ")",
+                _ => string
+            }
+        })
+        .collect()
 }
 
 pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String, String)> {


### PR DESCRIPTION
This PR fixes URL encoding of `InstanceID` values.

The Rust SDK follows the application/x-www-form-urlencoded percent-encode set for encoding. However, the VRChat API rejects percent-encoded parentheses (`%28` and `%29`) in `InstanceID` path parameters, returning a `400 "malformed url"` response instead of accepting the RFC-compliant encoding.

For example, the following request fails:

```text
https://api.vrchat.cloud/api/1/instances/wrld_28aab3e4-953f-4c85-9223-ef29a0873a6e:31124%7Egroup%28grp_b2a19685-c53e-4c5a-9503-744a5373bf2c%29%7EgroupAccessType%28plus%29%7Eregion%28use%29/shortName
```

```json
{"error":{"message":"\"malformed url\"","status_code":400,"waf_code":26497}}
```

Using the same `InstanceID` without encoding the parentheses succeeds as expected:

```text
https://vrchat.com/api/1/instances/wrld_28aab3e4-953f-4c85-9223-ef29a0873a6e:31124~group(grp_b2a19685-c53e-4c5a-9503-744a5373bf2c)~groupAccessType(plus)~region(use)/shortName
```

I initially encountered this issue in the Rust SDK, but it also affects the C# and Java SDK:

```cs
// Unhandled exception. VRChat.API.Client.ApiException: Error calling GetShortName: {"error":{"message":"\"malformed url\"","status_code":400,"waf_code":26497}}
await vrchat.Instances.GetShortNameAsync(
    "wrld_ba913a96-fac4-4048-a062-9aa5db092812",
    "31124~group(grp_b2a19685-c53e-4c5a-9503-744a5373bf2c)~groupAccessType(plus)~region(use)"
);
```

To better understand the behavior, I tested every ASCII character in both encoded and unencoded form against multiple API endpoints. The following reserved characters consistently resulted in malformed requests when percent-encoded:

```text
!$&'()*+,:;=@[\]
```

These all fall under `reserved` characters as defined in RFC3986 and are used for delimeters. The `~` character, despite my earlier assumption, does **not** exhibit this behavior when percent-encoded, which is consistent with it being part of the RFC 3986 unreserved character set.

The OpenAPI specification disallows the `:/?#[]@!$&'()*+,;=` characters from appearing in `path`, `query`, `cookie` and `header` parameters without encoding by default. It is possible to override this using `allowReserved`, but unfortunately that's exlusive to query parameters. The future OpenAPI 3.2 specification allows defining this for all relevant parameters, but it will take a while for it to be adopted.

Since modifying OpenAPI Generator itself is undesirable, I considered several alternatives:

1. Use `type: password` for the `Schema Object` 

This was my first attempt (See [#584](https://github.com/vrchatapi/specification/pull/584)), but it's confusing and doesn't appear to be properly supported by generator templates.

2. Removing url encoding.

This is an easy bandaid solution, but allowing strings to embed delimeters like "#" and "?" to adres any endpoint seems undesirable. The purpose of encoding is to prevent malicious strings from silently embedding delimeters, or developers from accidentally doing it themselves. 

3. Modifying the url encoding functions to accept "(" and ")".

This requires the SDKs to fork/patch url encoding functions like `form_urlencoded::byte_serialize` (Rust) or `Uri.EscapeDataString` (C#). RFC 3986 permits this behavior when a URI scheme explicitly treats reserved characters as data:

> URI producing applications should percent-encode data octets that correspond to characters in the reserved set unless these characters are specifically allowed by the URI scheme to represent data in that component.

This preserves the safety benefits of percent-encoding for all other reserved characters while making the minimal compatibility change required for the VRChat API.

4. Use `type: string` and combine it with `format: x-vrc-no-encode` for the `Schema Object` to conditionally skip encoding. 

This would allow overriding the templates, by disabling percent-encoding in the mustache template if `dataFormat` is defined. It makes the behavior explicit and allows similar problems to be addressed in the future. But, like method 2 it allows adding delimeters in an unsafe way for these values.

5. Use a vendor extension (`x-vrc-no-encode: true`) as part of the `Schema Object` to conditionally skip encoding. 

Same as method 4, but a vendor extension avoids conflating the data format with the encoding. This is better as the data format and encoding are not directly related. 

6. Break spec by defining `allowReserved` for a `path` parameter. 

Same as method 5. This aligns with the direction of OpenAPI 3.2, but it is invalid in OpenAPI 3.0/3.1 and would intentionally violate the current specification.

This PR adopts option 3. It makes the smallest possible change by preserving literal parentheses during URL encoding while continuing to percent-encode all other reserved characters. The SDK could also fork the byte_serialize function, but that'd require embedding unsafe Rust in the SDK.

I tested this patch on 1.20.7 as I'm having the following issue on main:
```
called `Result::unwrap()` on an `Err` value: ReqwestMiddleware(Reqwest(reqwest::Error { kind: Request, url: "https://api.vrchat.cloud/api/1/auth/user", source: hyper_util::client::legacy::Error(Connect, ConnectError("invalid URL, scheme is not http")) }))
```